### PR TITLE
Fix for class cast exception

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <artifactId>spring-data-marklogic</artifactId>
     <groupId>org.springframework.data</groupId>
-    <version>1.1.3.RELEASE</version>
+    <version>1.1.4.RELEASE</version>
 
     <name>Spring Data MarkLogic - Core</name>
     <description>MarkLogic support for Spring Data</description>

--- a/src/main/java/org/springframework/data/marklogic/core/MarkLogicTemplate.java
+++ b/src/main/java/org/springframework/data/marklogic/core/MarkLogicTemplate.java
@@ -285,7 +285,7 @@ public class MarkLogicTemplate implements MarkLogicOperations, ApplicationContex
 
     @Override
     public <T> List<T> write(List<T> entities, ServerTransform transform) {
-        return write(entities, transform);
+        return write(entities, transform, (String[]) null);
     }
 
     @Override

--- a/src/main/java/org/springframework/data/marklogic/repository/query/convert/DefaultMarkLogicQueryConversionService.java
+++ b/src/main/java/org/springframework/data/marklogic/repository/query/convert/DefaultMarkLogicQueryConversionService.java
@@ -274,27 +274,35 @@ public class DefaultMarkLogicQueryConversionService implements QueryConversionSe
         return options;
     }
 
-    @SuppressWarnings("unchecked")
     private static <T> T as(Object value, Class<T> type) {
         if (value instanceof Collection ||
                 value != null && (value.getClass().isArray() || !ClassUtils.isAssignable(type, value.getClass()))) {
             throw new IllegalArgumentException(
                     String.format("Expected parameter type of %s but got %s!", type, value.getClass()));
         }
-
-        return (T) value;
+        return cast(value);
     }
 
-    @SuppressWarnings("unchecked")
     private static <T> T[] asArray(Object values, Class<T[]> type) {
         if (values instanceof Collection) {
-            return (T[]) ((Collection<T>) values).toArray();
+            Collection<T> collection = cast(values);
+            return collection.toArray(newArray(type, collection.size()));
         } else if (values != null && values.getClass().isArray()) {
-            return (T[]) values;
+            return cast(values);
         } else if (values != null && String[].class.equals(type)){
             return Arrays.copyOf(new Object[] { values.toString() }, 1, type);
         } else {
             return Arrays.copyOf(new Object[] { values }, 1, type);
         }
+    }
+
+    @SuppressWarnings("unchecked")
+    private static <T> T cast(Object o) {
+        return (T) o;
+    }
+
+    @SuppressWarnings("unchecked")
+    private static <T> T[] newArray(Class<T[]> type, int size) {
+        return (T[]) java.lang.reflect.Array.newInstance(type.getComponentType(), size);
     }
 }


### PR DESCRIPTION
- Fixed a class cast exception when casting the result of Collection.toArray() to String[]
- Reverted the change in MarkLogicTemplate to include the final `null` argument, but with `(Collection<T>)` so the IDE won't complain.
- Tagged as 1.1.4